### PR TITLE
adds docutils as runtime dep, SPDX and pip check

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: True  # [win]
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
@@ -21,18 +21,22 @@ requirements:
     - python
     - pip
     - lockfile >=0.10
-    - docutils
   run:
     - python
     - lockfile >=0.10
+    - docutils
 
 test:
+  requires:
+    - pip
   imports:
     - daemon
+  commands:
+    - python -m pip check
 
 about:
   home: https://pagure.io/python-daemon/
-  license: Apache Software
+  license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE.ASF-2
   summary: Library to implement a well-behaved Unix daemon process.


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Trying to pull this into a rather large build, and am hitting some `pip check` issues: pretty sure this is a case of a bad dependency, as later versions move it to `setup_requires`, but it's a shame to lose a useful future tool. I guess a `setup.py` patch would also be an approach? 